### PR TITLE
Feature change cart clearing policy

### DIFF
--- a/src/TendoPay/Gateway.php
+++ b/src/TendoPay/Gateway.php
@@ -92,7 +92,8 @@ class Gateway extends WC_Payment_Gateway {
 		$payment_initiated = get_post_meta( $order_id, self::TENDOPAY_PAYMENT_INITIATED_KEY, true );
 
 		if ( $payment_initiated ) {
-			$payment_initiated_notice = __( "<strong>Warning!</strong><br><br>You've already initiated payment attempt with TendoPay once. If you continue you may end up finalizing two separate payments for single order.<br><br>Are you sure you want to continue?", 'tendopay' );
+			$payment_initiated_notice = __( "<strong>Warning!</strong><br><br>You've already initiated payment attempt with TendoPay once. If you continue you may end up finalizing two separate payments for single order.<br><br>Are you sure you want to continue?",
+				'tendopay' );
 
 			$notices = wc_get_notices();
 			if ( isset( $notices['notice'] ) && ! empty( $notices['notice'] ) ) {
@@ -126,14 +127,16 @@ class Gateway extends WC_Payment_Gateway {
 			),
 			self::OPTION_METHOD_DESC              => array(
 				'title'       => __( 'Payment method description', 'tendopay' ),
-				'description' => __( 'Additional information displayed to the customer after selecting TendoPay method', 'tendopay' ),
+				'description' => __( 'Additional information displayed to the customer after selecting TendoPay method',
+					'tendopay' ),
 				'type'        => 'textarea',
 				'default'     => '',
 				'desc_tip'    => true,
 			),
 			self::OPTION_TENDOPAY_SANDBOX_ENABLED => array(
 				'title'       => __( 'Enable SANDBOX', 'tendopay' ),
-				'description' => __( 'Enable SANDBOX if you want to test integration with TendoPay without real transactions.', 'tendopay' ),
+				'description' => __( 'Enable SANDBOX if you want to test integration with TendoPay without real transactions.',
+					'tendopay' ),
 				'type'        => 'checkbox',
 				'default'     => 'no',
 				'desc_tip'    => true,
@@ -210,10 +213,6 @@ class Gateway extends WC_Payment_Gateway {
 		$redirect_args = apply_filters( 'tendopay_process_payment_redirect_args_after_hash', $redirect_args, $order,
 			$this, $auth_token );
 
-		wc_reduce_stock_levels( $order->get_id() );
-
-		$woocommerce->cart->empty_cart();
-    
 		$redirect_args = urlencode_deep( $redirect_args );
 
 		$redirect_url = add_query_arg( $redirect_args, Constants::get_redirect_uri() );
@@ -223,8 +222,8 @@ class Gateway extends WC_Payment_Gateway {
 		update_post_meta( $order_id, self::TENDOPAY_PAYMENT_INITIATED_KEY, true );
 		wc_clear_notices();
 
-		
-		$redirect_url .= '&er=' . urlencode( $woocommerce->cart->get_checkout_url() );
+
+		$redirect_url .= '&er=' . urlencode( wc_get_checkout_url() );
 
 		return array(
 			'result'   => 'success',
@@ -241,6 +240,7 @@ class Gateway extends WC_Payment_Gateway {
 	 */
 	public function process_admin_options() {
 		delete_option( 'tendopay_bearer_token' );
+
 		return parent::process_admin_options();
 	}
 }

--- a/src/TendoPay/Gateway.php
+++ b/src/TendoPay/Gateway.php
@@ -197,11 +197,6 @@ class Gateway extends WC_Payment_Gateway {
 		$redirect_args = apply_filters( 'tendopay_process_payment_redirect_args_after_hash', $redirect_args, $order,
 			$this, $auth_token );
 
-		wc_reduce_stock_levels( $order->get_id() );
-
-		global $woocommerce;
-		$woocommerce->cart->empty_cart();
-
 		$redirect_args = urlencode_deep( $redirect_args );
 
 		$redirect_url = add_query_arg( $redirect_args, Constants::get_redirect_uri() );

--- a/src/TendoPay/Redirect_Url_Rewriter.php
+++ b/src/TendoPay/Redirect_Url_Rewriter.php
@@ -49,11 +49,7 @@ class Redirect_Url_Rewriter {
 	 * @return string url for redirection from TendoPay
 	 */
 	public function get_redirect_url() {
-		if ( is_writeable( ABSPATH . '.htaccess' ) ) {
-			return get_site_url( get_current_blog_id(), 'tendopay-result' );
-		} else {
-			return admin_url( 'admin-post.php?action=tendopay-result' );
-		}
+		return admin_url( 'admin-ajax.php?action=tendopay-result' );
 	}
 
 	/**
@@ -62,10 +58,7 @@ class Redirect_Url_Rewriter {
 	 * Adds rewrite rules to handle custom link.
 	 */
 	public function add_rules() {
-		$url = substr( admin_url( 'admin-post.php?action=tendopay-result' ), strlen( site_url() ) + 1 );
-		$url = apply_filters( 'tendopay_action_url', $url );
-
-		$redirect_url_pattern = apply_filters( 'tendopay_redirect_url_pattern', Constants::REDIRECT_URL_PATTERN );
-		add_rewrite_rule( $redirect_url_pattern, $url, 'top' );
+		// removed due to weird problems
+		// todo possibly remove the whole class
 	}
 }

--- a/src/TendoPay/TendoPay.php
+++ b/src/TendoPay/TendoPay.php
@@ -136,9 +136,7 @@ class TendoPay {
 			$order->payment_complete();
 			wp_redirect( $order->get_checkout_order_received_url() );
 		} else {
-			$checkout_payment_url = $order->get_checkout_payment_url();
-			$checkout_payment_url = add_query_arg( [ Constants::PAYMANET_FAILED_QUERY_PARAM => 1 ], $checkout_payment_url );
-			wp_redirect( $checkout_payment_url );
+			wp_redirect( wc_get_cart_url() );
 		}
 
 		exit;

--- a/src/TendoPay/TendoPay.php
+++ b/src/TendoPay/TendoPay.php
@@ -128,6 +128,11 @@ class TendoPay {
 		}
 
 		if ( $payment_completed ) {
+            global $woocommerce;
+            $woocommerce->cart->empty_cart();
+
+            wc_reduce_stock_levels( $order->get_id() );
+
 			$order->payment_complete();
 			wp_redirect( $order->get_checkout_order_received_url() );
 		} else {

--- a/src/TendoPay/TendoPay.php
+++ b/src/TendoPay/TendoPay.php
@@ -74,8 +74,8 @@ class TendoPay {
 		add_action( 'plugins_loaded', array( $this, 'init_gateway' ) );
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'register_gateway' ) );
 		add_action( 'plugins_loaded', array( Redirect_Url_Rewriter::class, 'get_instance' ) );
-		add_action( 'admin_post_tendopay-result', array( $this, 'handle_redirect_from_tendopay' ) );
-		add_action( 'admin_post_nopriv_tendopay-result', array( $this, 'handle_redirect_from_tendopay' ) );
+		add_action( 'wp_ajax_tendopay-result', array( $this, 'handle_redirect_from_tendopay' ) );
+		add_action( 'wp_ajax_nopriv_tendopay-result', array( $this, 'handle_redirect_from_tendopay' ) );
 	}
 
 	/**
@@ -107,6 +107,37 @@ class TendoPay {
 				__( 'Wrong order key provided', 'tendopay' ), 403 );
 		}
 
+		if ( $this->is_awaiting_payment( $order ) ) {
+			$this->perform_verification( $order, $posted_data );
+		} else {
+			wp_redirect( $order->get_checkout_order_received_url() );
+		}
+
+		exit;
+	}
+
+	/**
+     * Checks if the order is awaiting payment.
+     *
+	 * @param \WC_Order $order the order to be checked for payment status
+	 *
+	 * @return bool true if the order is awaiting payment
+	 */
+	private function is_awaiting_payment( \WC_Order $order ) {
+		return $order->has_status( apply_filters( 'woocommerce_valid_order_statuses_for_payment_complete',
+			array( 'on-hold', 'pending', 'failed', 'cancelled' ), $order ) );
+	}
+
+	/**
+     *
+	 * Does the actual verification, updates the stocks and empties the cart.
+	 *
+	 * @param \WC_Order $order order to be verified
+	 * @param array $posted_data posted data
+	 *
+	 * @throws \GuzzleHttp\Exception\GuzzleException when there's a problem in communication with TendoPay API
+	 */
+	private function perform_verification( \WC_Order $order, $posted_data ) {
 		$gateway_options             = get_option( "woocommerce_" . Gateway::GATEWAY_ID . "_settings" );
 		$tendo_pay_merchant_id       = $posted_data[ Constants::VENDOR_ID_PARAM ];
 		$local_tendo_pay_merchant_id = $gateway_options[ Gateway::OPTION_TENDOPAY_VENDOR_ID ];
@@ -117,8 +148,8 @@ class TendoPay {
 		}
 
 		try {
-			$verification      = new Verification_Endpoint();
-			$payment_completed = $verification->verify_payment( $order, $posted_data );
+			$verification         = new Verification_Endpoint();
+			$transaction_verified = $verification->verify_payment( $order, $posted_data );
 		} catch ( \Exception $exception ) {
 			error_log( $exception->getMessage() );
 			error_log( $exception->getTraceAsString() );
@@ -127,11 +158,11 @@ class TendoPay {
 				__( 'Could not communicate with TendoPay properly', 'tendopay' ), 403 );
 		}
 
-		if ( $payment_completed ) {
-            global $woocommerce;
-            $woocommerce->cart->empty_cart();
+		if ( $transaction_verified ) {
+			global $woocommerce;
+			$woocommerce->cart->empty_cart();
 
-            wc_reduce_stock_levels( $order->get_id() );
+			wc_reduce_stock_levels( $order->get_id() );
 
 			$order->payment_complete();
 			wp_redirect( $order->get_checkout_order_received_url() );


### PR DESCRIPTION
Payment by TendoPay should have similar flow to the Payment by PayPal:
- stocks should be reduced only when payment is successful
- cart should be cleared only when payment is successful
- when payment was not successful, customer should be taken to the basket, not to the `order payment` page
