### PR TITLE
Add minimum purchase amount error

### DIFF
--- a/src/TendoPay/Gateway.php
+++ b/src/TendoPay/Gateway.php
@@ -68,10 +68,22 @@ class Gateway extends WC_Payment_Gateway {
 
 	public function maybe_add_outstanding_balance_notice() {
 		$error = isset( $_GET['witherror'] ) ? htmlspecialchars( $_GET['witherror'] ) : '';
-		if ( $error == 'outstanding_balance' ) {
-			$notice =
-				__( "Your account has an outstanding balance, please repay your payment so you make an additional purchase.",
-					'tendopay' );
+		switch ( $error ) {
+			case 'outstanding_balance':
+				$notice =
+					__(
+						"Your account has an outstanding balance, please repay your payment so you make an additional purchase.",
+						'tendopay'
+					);
+				break;
+			case 'minimum_purchase':
+				// TODO replace 1000 to contant
+				$notice = __( "There is a minimum purchase amount of 1000 PHP.", 'tendopay' );
+				break;
+			default:
+				$notice = '';
+		}
+		if ( $notice ) {
 			wc_print_notice( $notice, 'error' );
 		}
 	}


### PR DESCRIPTION
@robklo @pmkay 

Please review this issue.  (https://github.com/archivum/TendoPay/issues/445)

An error message when the requested amount is less than the minimum purchase amount, 
the request returns back to the checkout page.
